### PR TITLE
relativeToWrapper bugfix

### DIFF
--- a/rellax.js
+++ b/rellax.js
@@ -371,8 +371,8 @@
     var deferredUpdate = function() {
       window.removeEventListener('resize', deferredUpdate);
       window.removeEventListener('orientationchange', deferredUpdate);
-      (self.options.wrapper ? self.options.wrapper : window).removeEventListener('scroll', deferredUpdate);
-      (self.options.wrapper ? self.options.wrapper : document).removeEventListener('touchmove', deferredUpdate);
+      (self.options.wrapper && !self.options.relativeToWrapper ? self.options.wrapper : window).removeEventListener('scroll', deferredUpdate);
+      (self.options.wrapper && !self.options.relativeToWrapper ? self.options.wrapper : document).removeEventListener('touchmove', deferredUpdate);
 
       // loop again
       loopId = loop(update);
@@ -391,8 +391,8 @@
         // Don't animate until we get a position updating event
         window.addEventListener('resize', deferredUpdate);
         window.addEventListener('orientationchange', deferredUpdate);
-        (self.options.wrapper ? self.options.wrapper : window).addEventListener('scroll', deferredUpdate, supportsPassive ? { passive: true } : false);
-        (self.options.wrapper ? self.options.wrapper : document).addEventListener('touchmove', deferredUpdate, supportsPassive ? { passive: true } : false);
+        (self.options.wrapper && !self.options.relativeToWrapper ? self.options.wrapper : window).addEventListener('scroll', deferredUpdate, supportsPassive ? { passive: true } : false);
+        (self.options.wrapper && !self.options.relativeToWrapper ? self.options.wrapper : document).addEventListener('touchmove', deferredUpdate, supportsPassive ? { passive: true } : false);
       }
     };
 


### PR DESCRIPTION
Added a condition to make sure scroll event listeners are not being applied to the wrapper element if `relativeToWrapper` is true